### PR TITLE
Feat/separate essay from scoring result

### DIFF
--- a/web/src/app/api/const/dataSet.ts
+++ b/web/src/app/api/const/dataSet.ts
@@ -5,7 +5,6 @@ const HIGH_DATA_TOTAL_NUMBER: number = 712;
 
 // Total 통계 데이터
 const TOTAL_STATISTICS: TotalStatistics = {
-  maxScore: 30,
   average: 25.5,
   standardDeviation: 3.45,
   data: {
@@ -34,7 +33,6 @@ const TOTAL_STATISTICS: TotalStatistics = {
 
 // EXP 통계 데이터
 const EXP_STATISTICS: SubStatistics = {
-  maxScore: 9,
   average: 7.7,
   standardDeviation: 1.29,
   data: {
@@ -56,7 +54,6 @@ const EXP_STATISTICS: SubStatistics = {
 
 // ORG 통계 데이터
 const ORG_STATISTICS: SubStatistics = {
-  maxScore: 12,
   average: 10.5,
   standardDeviation: 1.62,
   data: {
@@ -77,7 +74,6 @@ const ORG_STATISTICS: SubStatistics = {
 
 // CONT 통계 데이터
 const CONT_STATISTICS: SubStatistics = {
-  maxScore: 9,
   average: 7.3,
   standardDeviation: 1.2,
   data: {

--- a/web/src/app/api/const/dummyScore.ts
+++ b/web/src/app/api/const/dummyScore.ts
@@ -1,0 +1,57 @@
+const dummyScore = {
+  exp: {
+    title: '표현',
+    detail: [
+      { title: '문법의 적절성', score: 3, average: 2.4 },
+      {
+        title: '단어 사용의 적절성',
+        score: 3,
+        average: 2.4,
+      },
+      {
+        title: '문장 표현의 적절성',
+        score: 3,
+        average: 2.4,
+      },
+    ],
+  },
+  org: {
+    title: '구성',
+    detail: [
+      { title: '문단 내 구조의 적절성', score: 3, average: 2.4 },
+      {
+        title: '문단 간 구조의 적절성',
+        score: 3,
+        average: 2.4,
+      },
+      {
+        title: '구조의 일관성',
+        score: 3,
+        average: 2.4,
+      },
+      {
+        title: '분량의 적절성',
+        score: 3,
+        average: 2.4,
+      },
+    ],
+  },
+  cont: {
+    title: '내용',
+    detail: [
+      { title: '주제의 명료성', score: 3, average: 2.4 },
+      {
+        title: '근거의 적절성',
+        score: 3,
+        average: 2.4,
+      },
+      {
+        title: '프롬프트 독해력',
+        score: 3,
+        average: 2.4,
+      },
+    ],
+  },
+};
+
+export default dummyScore;

--- a/web/src/app/api/const/regExp.ts
+++ b/web/src/app/api/const/regExp.ts
@@ -1,0 +1,3 @@
+const COUNT_SENTENCES_REGEXP = /[.?!]+/g;
+
+export default COUNT_SENTENCES_REGEXP;

--- a/web/src/app/api/lib/scoring/makeScoringResult.ts
+++ b/web/src/app/api/lib/scoring/makeScoringResult.ts
@@ -73,11 +73,6 @@ const makeScoringResult = async (
     countCharacters,
     countSentences,
     essayId,
-    essayInfo: {
-      text: essay.essayText,
-      topic: essay.topic,
-      type: essay.type,
-    },
     uid: essay.uid,
 
     total: {

--- a/web/src/app/api/lib/scoring/makeScoringResult.ts
+++ b/web/src/app/api/lib/scoring/makeScoringResult.ts
@@ -5,7 +5,6 @@ import {
   ScoringResultEntity,
   Statistics,
 } from '@/app/api/lib/types';
-import reduceArray from '@/app/api/lib/utils/reduceArray';
 import {
   CONT_STATISTICS,
   EXP_STATISTICS,
@@ -16,6 +15,7 @@ import {
 import countEssay from '@/app/api/repository/essay/countEssay';
 import calculateGrade from '@/app/api/lib/scoring/calculateGrade';
 import reduceObject from '@/app/api/lib/utils/reduceObject';
+import COUNT_SENTENCES_REGEXP from '@/app/api/const/regExp';
 
 const makeScoringResult = async (
   subScore: ScoringResponseDto,
@@ -23,24 +23,22 @@ const makeScoringResult = async (
   essay: EssayEntitiy,
 ): Promise<ScoringResultEntity> => {
   const { exp, org, cont } = subScore;
-  const sentenceRegex = /[.?!]+/g;
-  const characterRegex = /\b\w+\b/g;
 
   // sum 계산에 필요한 callback 함수
   const sumCallback = (acc: number, cur: ScoringResponseSub) => {
     return acc + cur.score;
   };
-  const expSum = reduceArray(exp, sumCallback, 0);
-  const orgSum = reduceArray(org, sumCallback, 0);
-  const contSum = reduceArray(cont, sumCallback, 0);
+  const expSum = exp.reduce((acc, cur) => sumCallback(acc, cur), 0);
+  const orgSum = org.reduce((acc, cur) => sumCallback(acc, cur), 0);
+  const contSum = cont.reduce((acc, cur) => sumCallback(acc, cur), 0);
   const totalSum = expSum + orgSum + contSum;
 
   // 글자수, 문장수 계산
-  const sentences = essay.essayText.match(sentenceRegex);
+  const sentences = essay.essayText.match(COUNT_SENTENCES_REGEXP);
   const countSentences = sentences ? sentences.length : 0;
 
-  const characters = essay.essayText.match(characterRegex);
-  const countCharacters = characters ? characters.length : 0;
+  // 글자 수 계산
+  const countCharacters = essay.essayText.trim().length;
 
   // percentage 계산에 필요한 callback 함수
   const percentageCallback = (sum: number) => {

--- a/web/src/app/api/lib/types.d.ts
+++ b/web/src/app/api/lib/types.d.ts
@@ -33,24 +33,6 @@ export interface ScoringResponseDto {
   cont: { title: string; detail: ScoringResponseDetail[] };
 }
 
-// export interface EvaluateResponseDto {
-//   candidate: number; // 전체 참여자 수
-//   countCharacters: number; // 글자 수
-//   countSentences: number; // 문장수
-//   createdAt: string; // 생성일
-//   essayId: string; // essayId
-//   essayInfo: {
-//     text: string;
-//     topic: string;
-//     type: string;
-//   };
-//
-//   total: EssayTotal;
-//   exp: EssaySub;
-//   org: EssaySub;
-//   cont: EssaySub;
-// }
-
 // Statistics. 채점 결과 결과 통계 interface
 export interface Statistics {
   average: number;
@@ -85,24 +67,29 @@ export interface EssaySub extends Essay {
   detail: ScoringResponseDetail[];
 }
 
-// DB 구조
-export interface ScoringResultEntity {
+interface ScoringResult {
   candidate: number; // 전체 참여자 수
   countCharacters: number; // 글자 수
   countSentences: number; // 문장수
   essayId: string; // essayId
+  total: EssayTotal;
+  exp: EssaySub;
+  org: EssaySub;
+  cont: EssaySub;
+  createdAt?: string; // 생성일
+}
+
+// DB 구조
+export interface ScoringResultEntity extends ScoringResult {
+  uid: string | null; // 유저 ID
+}
+
+export interface ScoringResultResponse extends ScoringResult {
   essayInfo: {
     text: string;
     topic: string;
     type: string;
   };
-
-  total: EssayTotal;
-  exp: EssaySub;
-  org: EssaySub;
-  cont: EssaySub;
-  uid: string | null; // 유저 ID
-  createdAt?: string; // 생성일
 }
 
 export interface EssayEntitiy {

--- a/web/src/app/api/lib/types.d.ts
+++ b/web/src/app/api/lib/types.d.ts
@@ -21,33 +21,50 @@ export interface EvaluateRequestDto {
   essayText: string;
 }
 
-export interface ScoringResponseSub {
+export interface ScoringResponseDetail {
   title: string;
   score: number;
   average: number;
 }
+
 export interface ScoringResponseDto {
-  exp: ScoringResponseSub[];
-  org: ScoringResponseSub[];
-  cont: ScoringResponseSub[];
+  exp: { title: string; detail: ScoringResponseDetail[] };
+  org: { title: string; detail: ScoringResponseDetail[] };
+  cont: { title: string; detail: ScoringResponseDetail[] };
 }
 
-export interface EvaluateResponseDto {
-  candidate: number; // 전체 참여자 수
-  countCharacters: number; // 글자 수
-  countSentences: number; // 문장수
-  createdAt: string; // 생성일
-  essayId: string; // essayId
-  essayInfo: {
-    text: string;
-    topic: string;
-    type: string;
-  };
+// export interface EvaluateResponseDto {
+//   candidate: number; // 전체 참여자 수
+//   countCharacters: number; // 글자 수
+//   countSentences: number; // 문장수
+//   createdAt: string; // 생성일
+//   essayId: string; // essayId
+//   essayInfo: {
+//     text: string;
+//     topic: string;
+//     type: string;
+//   };
+//
+//   total: EssayTotal;
+//   exp: EssaySub;
+//   org: EssaySub;
+//   cont: EssaySub;
+// }
 
-  total: EssayTotal;
-  exp: EssaySub;
-  org: EssaySub;
-  cont: EssaySub;
+// Statistics. 채점 결과 결과 통계 interface
+export interface Statistics {
+  average: number;
+  standardDeviation: number;
+  data: { [key: number]: number };
+  min: number;
+  max: number;
+  median: number;
+  Q1: number;
+  Q3: number;
+}
+export interface TotalStatistics extends Statistics {}
+export interface SubStatistics extends Statistics {
+  detail: number[];
 }
 
 // Essay.
@@ -61,31 +78,11 @@ export interface Essay {
   median: number;
   Q1: number;
   Q3: number;
+  title: string;
 }
 export interface EssayTotal extends Essay {}
 export interface EssaySub extends Essay {
-  detail: {
-    title: string;
-    score: number;
-    average: number;
-  }[];
-}
-
-// Statistics. 채점 결과 결과 통계 interface
-export interface Statistics {
-  maxScore: number;
-  average: number;
-  standardDeviation: number;
-  data: { [key: number]: number };
-  min: number;
-  max: number;
-  median: number;
-  Q1: number;
-  Q3: number;
-}
-export interface TotalStatistics extends Statistics {}
-export interface SubStatistics extends Statistics {
-  detail: number[];
+  detail: ScoringResponseDetail[];
 }
 
 // DB 구조

--- a/web/src/app/api/lib/utils/reduceArray.ts
+++ b/web/src/app/api/lib/utils/reduceArray.ts
@@ -1,5 +1,0 @@
-const reduceArray = <T, F>(arr: T[], callback: Function, initialVal: F) => {
-  return arr.reduce((acc, cur) => callback(acc, cur), initialVal);
-};
-
-export default reduceArray;

--- a/web/src/app/api/lib/utils/reduceObject.ts
+++ b/web/src/app/api/lib/utils/reduceObject.ts
@@ -2,7 +2,7 @@ const reduceObject = <T>(
   obj: { [key: string | number]: T },
   callback: Function,
   initialVal: T,
-) => {
+): T => {
   return Object.entries(obj).reduce(
     (acc, [key, value]) => callback(acc, value, key),
     initialVal,

--- a/web/src/app/api/repository/essay/findEssayById.ts
+++ b/web/src/app/api/repository/essay/findEssayById.ts
@@ -1,0 +1,25 @@
+import { db } from '@/app/api/config/firebase.admin';
+import ApiError from '@/app/api/lib/class/ApiError';
+import { EssayEntitiy } from '@/app/api/lib/types';
+
+const findEssayById = async (essayId: string): Promise<EssayEntitiy> => {
+  try {
+    const doc = db.collection('Essay').doc(essayId);
+    const result = await doc.get();
+    const res = result.data() as EssayEntitiy;
+
+    if (!res) {
+      throw new ApiError(
+        `${essayId}에 해당하는 essay를 찾을 수 없음`,
+        404,
+        '제출 답안을 찾을 수 없습니다.',
+      );
+    }
+
+    return res;
+  } catch (err) {
+    throw ApiError.handleError(err);
+  }
+};
+
+export default findEssayById;

--- a/web/src/app/api/repository/essay/saveEssay.ts
+++ b/web/src/app/api/repository/essay/saveEssay.ts
@@ -4,9 +4,7 @@ import { EssayEntitiy } from '@/app/api/lib/types';
 
 const saveEssay = async (essay: EssayEntitiy, docId?: string) => {
   try {
-    const doc = docId
-      ? db.collection('Essay').doc(docId)
-      : db.collection('Essay').doc();
+    const doc = db.collection('Essay').doc(docId ?? '');
 
     await doc.set(essay);
 

--- a/web/src/app/api/repository/scoringResult/findScoringResultByEssayId.ts
+++ b/web/src/app/api/repository/scoringResult/findScoringResultByEssayId.ts
@@ -1,20 +1,23 @@
 import { db } from '@/app/api/config/firebase.admin';
 import ApiError from '@/app/api/lib/class/ApiError';
+import { ScoringResultEntity } from '@/app/api/lib/types';
 
-const findScoringResultByEssayId = async (essayId: string) => {
+const findScoringResultByEssayId = async (
+  essayId: string,
+): Promise<ScoringResultEntity> => {
   try {
     const doc = db.collection('ScoringResult').doc(essayId);
-
     const result = await doc.get();
+    const res = result.data() as ScoringResultEntity;
 
-    if (!result.exists)
+    if (!res)
       throw new ApiError(
-        'essayId에 해당하는 결과가 존재하지 않음',
+        `${essayId}에 해당하는 결과가 존재하지 않음`,
         404,
         '채점 결과가 존재하지 않습니다.',
       );
 
-    return result.data();
+    return res;
   } catch (err) {
     throw ApiError.handleError(err);
   }

--- a/web/src/app/api/repository/scoringResult/saveScoringResult.ts
+++ b/web/src/app/api/repository/scoringResult/saveScoringResult.ts
@@ -7,9 +7,7 @@ const saveScoringResult = async (
   docId?: string,
 ) => {
   try {
-    const doc = docId
-      ? db.collection('ScoringResult').doc(docId)
-      : db.collection('ScoringResult').doc();
+    const doc = db.collection('ScoringResult').doc(docId ?? '');
 
     await doc.set(scoringResult);
 

--- a/web/src/app/api/v1/evaluate/[essayId]/result/route.ts
+++ b/web/src/app/api/v1/evaluate/[essayId]/result/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import ApiError from '@/app/api/lib/class/ApiError';
 import findScoringResultByEssayId from '@/app/api/repository/scoringResult/findScoringResultByEssayId';
+import findEssayById from '@/app/api/repository/essay/findEssayById';
+import { ScoringResultResponse } from '@/app/api/lib/types';
 
 export async function GET(
   req: NextRequest,
@@ -8,8 +10,23 @@ export async function GET(
 ) {
   try {
     const { essayId } = params;
-    const res = await findScoringResultByEssayId(essayId);
+    const { uid, ...remainScoringResult } = await findScoringResultByEssayId(
+      essayId,
+    );
+    const {
+      essayText: text,
+      createdAt,
+      uid: essayUid,
+      ...remainEssay
+    } = await findEssayById(essayId);
 
+    const res: ScoringResultResponse = {
+      ...remainScoringResult,
+      essayInfo: {
+        text,
+        ...remainEssay,
+      },
+    };
     return NextResponse.json(res, { status: 200 });
   } catch (err) {
     console.log(err);

--- a/web/src/app/api/v1/evaluate/route.ts
+++ b/web/src/app/api/v1/evaluate/route.ts
@@ -6,6 +6,7 @@ import getDecodedToken from '@/app/api/lib/auth/getDecodedToken';
 import saveScoringResult from '@/app/api/repository/scoringResult/saveScoringResult';
 import makeCreatedAt from '@/app/api/lib/makeCreatedAt';
 import makeScoringResult from '@/app/api/lib/scoring/makeScoringResult';
+import dummyScore from '@/app/api/const/dummyScore';
 
 export async function POST(req: NextRequest) {
   try {
@@ -57,26 +58,7 @@ export async function POST(req: NextRequest) {
     // const subScore: ScoringResponseDto = await fetchToScoringServer(
     //   replaceText,
     // );
-
-    // dummy data
-    const subScore = {
-      exp: [
-        { title: '문법의 적절성', score: 3, average: 2.4 },
-        { title: '단어 사용의 적절성', score: 3, average: 2.4 },
-        { title: '문장 표현의 적절성', score: 3, average: 2.4 },
-      ],
-      org: [
-        { title: '문법의 적절성2', score: 3, average: 2.4 },
-        { title: '단어 사용의 적절성2', score: 3, average: 2.4 },
-        { title: '문장 표현의 적절성2', score: 3, average: 2.4 },
-        { title: '문법의 적절성2', score: 3, average: 2.4 },
-      ],
-      cont: [
-        { title: '문법의 적절성3', score: 3, average: 2.4 },
-        { title: '단어 사용의 적절성3', score: 3, average: 2.4 },
-        { title: '문장 표현의 적절성3', score: 3, average: 2.4 },
-      ],
-    };
+    const subScore = dummyScore;
 
     // 채점 결과 객체에서 ScoringResult 객체 재조합
     const scoringResult: ScoringResultEntity = await makeScoringResult(


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] 코드 리펙토링
- [ ] 테스트 코드, 리펙토링 테스트 코드 추가
- [ ] 빌드 업무 수정, 패키지 매니저 수정

## 변경 사항
1. ScoringResult DB에 있던 essay text, type, topic 제거.
2. 피드백 받은 사항 일부 수정.

## 변경 이유
1. History를 불러올 때, 모든 result 데이터가 전송되는데, 이때 essayText를 전송할 필요가 없다고 판단됨.

## 추가 설명
1. GET [경로]/result 가 호출되었을 시, ScoringResult와 Essay를 각각 불러옴.

## 스크린샷

## 체크리스트

- [x] PR 제목은 유의미한가요?
- [x] PR 내용만 보고도 이해할 수 있을 정도로 기술되었나요?
- [x] 관련 reference가 있다면 함께 적었나요?
- [x] Reviewer, Label을 붙였나요?
