### PR TITLE
feat: wordcloud와 scoring server fetch 통합

### DIFF
--- a/web/src/app/api/lib/scoring/fetchToScoringServer.ts
+++ b/web/src/app/api/lib/scoring/fetchToScoringServer.ts
@@ -1,5 +1,6 @@
 import ApiError from '@/app/api/lib/class/ApiError';
 import TOPIC_ID_SERVER_MAP from '@/app/api/const/topicIdServerMap';
+import fetchToWordCloudServer from '@/app/api/lib/wordCloud/fetchToWordCloudServer';
 
 const fetchToScoringServer = async (
   essayText: string,
@@ -9,21 +10,25 @@ const fetchToScoringServer = async (
   try {
     const URL_MAP = TOPIC_ID_SERVER_MAP[id];
 
-    const fetchResult = await Promise.all(
-      Object.values(URL_MAP).map(async (url) => {
-        const res = await fetch(url, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ essayText }),
-        });
+    const scoringList = Object.values(URL_MAP).map(async (url) => {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ essayText }),
+      });
 
-        const result = await res.json();
-        console.log(result, url);
-        return result;
-      }),
-    );
+      const result = await res.json();
+      console.log(result, url);
+      return result;
+    });
+
+    // wordCloud 추가
+    const wordCloud = fetchToWordCloudServer(essayText);
+    scoringList.push(wordCloud);
+
+    const fetchResult = await Promise.all(scoringList);
 
     return fetchResult;
   } catch (err) {

--- a/web/src/app/api/lib/wordCloud/fetchToWordCloudServer.ts
+++ b/web/src/app/api/lib/wordCloud/fetchToWordCloudServer.ts
@@ -1,15 +1,22 @@
+import ApiError from '@/app/api/lib/class/ApiError';
+
 const fetchToWordCloudServer = async (essayText: string) => {
-  const fetchResult = await fetch(`${process.env.WORD_CLOUD_SERVER}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ essayText }),
-  });
+  try {
+    const fetchResult = await fetch(`${process.env.WORD_CLOUD_SERVER}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ essayText }),
+    });
 
-  const result: { [key: string]: number } = await fetchResult.json();
+    const result: { [key: string]: number } = await fetchResult.json();
+    console.log('wordcloud 분석 결과: ', result);
 
-  return result;
+    return result;
+  } catch (err) {
+    throw ApiError.handleError(err);
+  }
 };
 
 export default fetchToWordCloudServer;


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] 코드 리펙토링
- [ ] 테스트 코드, 리펙토링 테스트 코드 추가
- [ ] 빌드 업무 수정, 패키지 매니저 수정

## 변경 사항
1. wordCloud 와 scoring fetch를 promise.all로 통합하였습니다.
2. fetchToScoringServer 내부에 fetchToWordCloud 함수를 넣어서 배열로 반환합니다.

## 변경 이유

## 추가 설명
1. 함수 네이밍 변경 예정.
2. promise.all 사용시 리스트의 순서가 변경되지 않기 때문에 scoringList.push(wordCloud); 를  사용하여 리스트의 마지막 요소에 wordCloud 채점 객체를 담는 방식 사용 

## 스크린샷

## 체크리스트

- [x] PR 제목은 유의미한가요?
- [x] PR 내용만 보고도 이해할 수 있을 정도로 기술되었나요?
- [x] 관련 reference가 있다면 함께 적었나요?
- [x] Reviewer, Label을 붙였나요?
